### PR TITLE
Added RadioButton onselected, ProgressBar value getter, and renamed some parameters for consistency

### DIFF
--- a/ui.nim
+++ b/ui.nim
@@ -217,13 +217,13 @@ type
     impl*: ptr rawui.Tab
     children*: seq[Widget]
 
-proc add*[SomeWidget: Widget](t: Tab; name: string; c: SomeWidget) =
-  tabAppend t.impl, name, c.impl
-  t.children.add c
+proc add*[SomeWidget: Widget](t: Tab; name: string; child: SomeWidget) =
+  tabAppend t.impl, name, child.impl
+  t.children.add child
 
-proc insertAt*[SomeWidget: Widget](t: Tab; name: string; at: int; c: SomeWidget) =
-  tabInsertAt(t.impl, name, at.uint64, c.impl)
-  t.children.insert(c, at)
+proc insertAt*[SomeWidget: Widget](t: Tab; name: string; at: int; child: SomeWidget) =
+  tabInsertAt(t.impl, name, at.uint64, child.impl)
+  t.children.insert(child, at)
 
 proc delete*(t: Tab; index: int) =
   tabDelete(t.impl, index.cint)
@@ -249,9 +249,9 @@ type
 proc title*(g: Group): string = $groupTitle(g.impl)
 proc `title=`*(g: Group; title: string) =
   groupSetTitle(g.impl, title)
-proc `child=`*[SomeWidget: Widget](g: Group; c: SomeWidget) =
-  groupSetChild(g.impl, c.impl)
-  g.child = c
+proc `child=`*[SomeWidget: Widget](g: Group; child: SomeWidget) =
+  groupSetChild(g.impl, child.impl)
+  g.child = child
 proc margined*(g: Group): bool = groupMargined(g.impl) != 0
 proc `margined=`*(g: Group; x: bool) =
   groupSetMargined(g.impl, x.cint)
@@ -305,6 +305,8 @@ type
 
 proc `value=`*(p: ProgressBar; n: int) =
   progressBarSetValue p.impl, n.cint
+
+proc value*(p: Progressbar; n:int): int = progressBarValue(p.impl)
 
 proc newProgressBar*(): ProgressBar =
   newFinal result
@@ -370,12 +372,20 @@ proc newEditableCombobox*(onchanged: proc () = nil): EditableCombobox =
 type
   RadioButtons* = ref object of Widget
     impl*: ptr rawui.RadioButtons
+    onselected*: proc ()
 
 proc add*(r: RadioButtons; text: string) =
   radioButtonsAppend(r.impl, text)
-proc newRadioButtons*(): RadioButtons =
+proc selected*(r: RadioButtons): int = radioButtonsSelected(r.impl)
+proc `selected=`*(r: RadioButtons; n: int) = radioButtonsSetSelected r.impl, cint n
+
+voidCallback wraprbOnSelected, RadioButtons, RadioButtons, onselected
+
+proc newRadioButtons*(onSelected: proc() = nil): RadioButtons =
   newFinal result
   result.impl = rawui.newRadioButtons()
+  result.onSelected = onSelected
+  radioButtonsOnSelected(result.impl, wraprbOnSelected, cast[pointer](result))
 
 # ------------------------ MultilineEntry ------------------------------
 


### PR DESCRIPTION
For some reason RadioButtons didn't have an onselected field nor the functions to add one. These have been added in the same style as the combobox.

ProgressBar had only a setter and no getter, while a getter is probably never used for a progress bar I feel it should at least have one in case you need it.

Also renamed some of the parameters on the form "c: SomeWidget" to "child: SomeWidget" to be consistent across the library.