### PR TITLE
Add res folder to fix building on Windows

### DIFF
--- a/ui.nimble
+++ b/ui.nimble
@@ -5,7 +5,7 @@ author        = "Andreas Rumpf"
 description   = "Nim\'s official UI library"
 license       = "MIT"
 
-installDirs = @["ui"]
+installDirs = @["ui","res"]
 installFiles = @["ui.nim"]
 
 # Dependencies


### PR DESCRIPTION
Add the "res" folder to what is installed by Nimble. This appears to be required for building successfully on Windows.

Tested & confirmed working when using VCC.