### PR TITLE
Change proc 'random' to 'rand' on examples.

### DIFF
--- a/examples/histogram.nim
+++ b/examples/histogram.nim
@@ -269,7 +269,7 @@ proc main*() {.cdecl.} =
   i = 0
   while i < 10:
     datapoints[i] = newSpinbox(0, 100)
-    spinboxSetValue(datapoints[i], random(101).cint)
+    spinboxSetValue(datapoints[i], rand(101).cint)
     spinboxOnChanged(datapoints[i], onDatapointChanged, nil)
     boxAppend(vbox, datapoints[i], 0)
     inc(i)

--- a/examples/table.nim
+++ b/examples/table.nim
@@ -31,7 +31,7 @@ proc modelCellValue(mh: ptr TableModelHandler, m: TableModel, row, col: int): pt
     result = newTableValueString($(row+1))
   elif col == COLUMN_PROCESS:
     if progress[row][col] == 0:
-      progress[row][col] = random(100)
+      progress[row][col] = rand(100)
     result = newTableValueInt(progress[row][col])
   #elif col == COLUMN_PASSED:
   #  if progress[row][col] > 60:


### PR DESCRIPTION
proc `random` is deprecated.

```bash
$ for f in *.nim; do nim c --verbosity:0 --hints:off $f; done
/tmp/examples/histogram.nim(272, 36) Warning: Deprecated since v0.18.0; use 'rand' instead; random is deprecated [Deprecated]
/tmp/examples/histogram.nim(272, 36) Warning: Deprecated since v0.18.0; use 'rand' instead; random is deprecated [Deprecated]
/tmp/examples/table.nim(34, 28) Warning: Deprecated since v0.18.0; use 'rand' instead; random is deprecated [Deprecated]
```