### PR TITLE
fix cross-compile with mingw

### DIFF
--- a/ui/rawui.nim
+++ b/ui/rawui.nim
@@ -48,12 +48,12 @@ else:
     {.passL: r"-lcomctl32".}
     {.passL: r"-ld2d1".}
     {.passL: r"-ldwrite".}
-    {.passL: r"-lUxTheme".}
-    {.passL: r"-lUsp10".}
+    {.passL: r"-luxtheme".}
+    {.passL: r"-lusp10".}
     {.passL: r"-lgdi32".}
     {.passL: r"-luser32".}
     {.passL: r"-lkernel32".}
-    {.link: r"..\res\resources.o".}
+    {.link: r"../res/resources.o".}
 
   when defined(vcc):
     {.passC: "/EHsc".}


### PR DESCRIPTION
Fix cross-compilation to Windows on Linux using x86_64-w64-mingw32-gcc.
Linux is case- and slash-sensitive, but Windows should be able to handle
both afaik.

This should fix #16.

Maybe someone can verify that this works (with gcc) on Windows too?